### PR TITLE
Create envelope to validate mail

### DIFF
--- a/lib/gravity_mailbox/rails_cache_delivery_method.rb
+++ b/lib/gravity_mailbox/rails_cache_delivery_method.rb
@@ -14,6 +14,10 @@ module GravityMailbox
     end
 
     def deliver!(mail)
+      # https://github.com/mikel/mail/blob/d1d65b370b109b98e673a934e8b70a0c1f58cc59/lib/mail/network/delivery_methods/test_mailer.rb#L39
+      # Create the envelope to validate it
+      Mail::SmtpEnvelope.new(mail)
+
       key = "#{KEY_PREFIX}#{mail.message_id}"
       Rails.cache.write(key, mail.encoded, expires_in: 1.week) # TODO: setting for expiration
       actual_list = self.class.mail_keys

--- a/spec/gravity_mailbox/rails_cache_delivery_method_spec.rb
+++ b/spec/gravity_mailbox/rails_cache_delivery_method_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GravityMailbox::RailsCacheDeliveryMethod do
       )
     end
 
-    context 'envelope validation' do
+    describe 'envelope validation' do
       context 'when mail has no sender' do
         let(:mail) do
           Mail.new.tap do |m|

--- a/spec/gravity_mailbox/rails_cache_delivery_method_spec.rb
+++ b/spec/gravity_mailbox/rails_cache_delivery_method_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe GravityMailbox::RailsCacheDeliveryMethod do
     let(:mail) do
       Mail.new.tap do |m|
         m.message_id = '123'
+        m.from = 'sender@example.com'
+        m.to = 'recipient@example.com'
       end
     end
 
@@ -25,6 +27,48 @@ RSpec.describe GravityMailbox::RailsCacheDeliveryMethod do
         'gravity_mailbox/list',
         ["gravity_mailbox/#{mail.message_id}"]
       )
+    end
+
+    context 'envelope validation' do
+      context 'when mail has no sender' do
+        let(:mail) do
+          Mail.new.tap do |m|
+            m.message_id = '123'
+            m.to = 'recipient@example.com'
+          end
+        end
+
+        it 'raises an error' do
+          expect { delivering }.to raise_error(ArgumentError, /SMTP From address may not be blank/)
+        end
+      end
+
+      context 'when mail has no recipients' do
+        let(:mail) do
+          Mail.new.tap do |m|
+            m.message_id = '123'
+            m.from = 'sender@example.com'
+          end
+        end
+
+        it 'raises an error' do
+          expect { delivering }.to raise_error(ArgumentError, /SMTP To address may not be blank/)
+        end
+      end
+
+      context 'when mail has invalid from address' do
+        let(:mail) do
+          Mail.new.tap do |m|
+            m.message_id = '123'
+            m.from = ''
+            m.to = 'recipient@example.com'
+          end
+        end
+
+        it 'raises an error' do
+          expect { delivering }.to raise_error(ArgumentError, /SMTP From address may not be blank/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This pull request improves the reliability of the `RailsCacheDeliveryMethod` by adding envelope validation to ensure that emails have valid sender and recipient addresses before delivery. It also enhances the test suite to cover these validation scenarios. Fix #24 

**Envelope validation improvements:**

* In `lib/gravity_mailbox/rails_cache_delivery_method.rb`, the `deliver!` method now creates a `Mail::SmtpEnvelope` for the email, which validates the presence of sender and recipient addresses before caching the mail.

**Test coverage enhancements:**

* In `spec/gravity_mailbox/rails_cache_delivery_method_spec.rb`, the test mail setup now includes explicit `from` and `to` addresses to ensure valid envelope data for standard cases.
* Added new test contexts to verify that an error is raised if the mail has no sender, no recipients, or an invalid sender address, ensuring that envelope validation is properly enforced.